### PR TITLE
Add support for Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
     ],
     "require": {
         "php": ">=7.1",
-        "symfony/dependency-injection": "~3.3",
-        "symfony/config": "~3.3",
-        "symfony/http-kernel": "~3.3"
+        "symfony/dependency-injection": "~3.3|~4.0",
+        "symfony/config": "~3.3|~4.0",
+        "symfony/http-kernel": "~3.3|~4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.3",
+        "phpunit/phpunit": "~6.3|~7.0",
         "doctrine/orm": "^2.6"
     },
     "autoload": {


### PR DESCRIPTION
After update to Symfony 4.1.5, requirements for Symfony ~3.0 components can not be satisfied