### PR TITLE
Upgrade to Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "php": ">=7.1",
-        "symfony/dependency-injection": "~3.3|~4.0",
-        "symfony/config": "~3.3|~4.0",
-        "symfony/http-kernel": "~3.3|~4.0",
+        "symfony/dependency-injection": "~3.3|~4.0|~5.0",
+        "symfony/config": "~3.3|~4.0|~5.0",
+        "symfony/http-kernel": "~3.3|~4.0|~5.0",
         "tuscanicz/enum": "~2.0"
     },
     "require-dev": {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,8 +19,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('tuscanicz_datetime');
+        $treeBuilder = new TreeBuilder('tuscanicz_datetime');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()


### PR DESCRIPTION
This updates the library to support symfony 5. Should be released as major version as it breaks compatibility with symfony 4 and earlier.

Backwards compatibility can be achieved with 
```
    	$treeBuilder = new TreeBuilder('tuscanicz_datetime');
        $rootNode = $treeBuilder->root('tuscanicz_datetime');	


         // Keep compatibility with symfony/config < 4.2
        if (\method_exists($treeBuilder, 'getRootNode')) {
            $rootNode = $treeBuilder->getRootNode();
        } else {
            $rootNode = $treeBuilder->root('tuscanicz_datetime');
        }
```

not sure if its good idea tho