### PR TITLE
fix doctrine types generate diffs constantly

### DIFF
--- a/src/Date/Doctrine/DateType.php
+++ b/src/Date/Doctrine/DateType.php
@@ -74,4 +74,13 @@ class DateType extends Type
     {
         return \PDO::PARAM_STR;
     }
+
+    /**
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     * @return bool
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/src/Doctrine/DateTimeType.php
+++ b/src/Doctrine/DateTimeType.php
@@ -82,4 +82,13 @@ class DateTimeType extends Type
     {
         return \PDO::PARAM_STR;
     }
+
+    /**
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     * @return bool
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
If this Doctrine Type maps to an already mapped database type,
reverse schema engineering can't tell them apart. You need to mark
one of those types as commented, which will have Doctrine use an SQL
comment to typehint the actual Doctrine Type.

usecase - I create a migration with `@ORM\Column(type='datetime_immutable')`,
proced with the migration. Upon next `doctrine:migrations:diff`
new diff is crated: `ALTER TABLE foo_table CHANGE bar_column bar_column DATE NOT NULL;`
but the changed column definition is the same as before.